### PR TITLE
Add allizom.org for testing

### DIFF
--- a/stubservice/stubhandlers/sourcewhitelist.go
+++ b/stubservice/stubhandlers/sourcewhitelist.go
@@ -4,6 +4,7 @@ var sourceWhitelist = map[string]bool{
 	"accounts.firefox.com":           true,
 	"activations.cdn.mozilla.net":    true,
 	"addons.mozilla.org":             true,
+	"allizom.org":                    true,
 	"answers.yahoo.com":              true,
 	"ar.search.yahoo.com":            true,
 	"at.search.yahoo.com":            true,


### PR DESCRIPTION
@oremj r?  And if so, would you mind merging and pushing to staging?

This is untested, but I think we need this to properly test on *.allizom.org sites.

Spoke with @alexgibson and we think it's (one of?) the missing piece(s) to enable full end-to-end testing, starting with https://www-demo4.allizom.org 