### PR TITLE
Revert "validator: the code has been validated, so use it instead of trying to re-encode"

### DIFF
--- a/attributioncode/validator.go
+++ b/attributioncode/validator.go
@@ -76,7 +76,7 @@ func (v *Validator) Validate(code, sig string) (string, error) {
 		return "", fmt.Errorf("source: %s is not in whitelist", source)
 	}
 
-	return code, nil
+	return url.QueryEscape(vals.Encode()), nil
 }
 
 func (v *Validator) validateSignature(code, sig string) error {

--- a/attributioncode/validator_test.go
+++ b/attributioncode/validator_test.go
@@ -64,7 +64,7 @@ func TestValidateAttributionCode(t *testing.T) {
 	}{
 		{
 			"source%3Dwww.google.com%26medium%3Dorganic%26campaign%3D(not%20set)%26content%3D(not%20set)",
-			"source%3Dwww.google.com%26medium%3Dorganic%26campaign%3D(not%20set)%26content%3D(not%20set)",
+			"campaign%3D%2528not%2Bset%2529%26content%3D%2528not%2Bset%2529%26medium%3Dorganic%26source%3Dwww.google.com",
 		},
 	}
 	for _, c := range validCodes {


### PR DESCRIPTION
Reverts mozilla-services/stubattribution#37