### PR TITLE
Add a prefix for RTAMO in the storage key

### DIFF
--- a/attributioncode/validator.go
+++ b/attributioncode/validator.go
@@ -93,6 +93,12 @@ func (c *Code) URLEncode() string {
 	return url.QueryEscape(c.rawURLVals.Encode())
 }
 
+// FromRTAMO returns true when the content parameter contains a prefix for
+// RTAMO, and false otherwise.
+func (c *Code) FromRTAMO() bool {
+	return rtamo.MatchString(c.Content)
+}
+
 // Validator validates and returns santized attribution codes
 type Validator struct {
 	HMACKey string
@@ -187,7 +193,7 @@ func (v *Validator) Validate(code, sig, refererHeader string) (*Code, error) {
 		rawURLVals: vals,
 	}
 
-	if fromRTAMO(attributionCode.Content) {
+	if attributionCode.FromRTAMO() {
 		refererMatch := mozillaOrg.MatchString(refererHeader)
 
 		if !refererMatch {
@@ -216,8 +222,4 @@ func checkMAC(key, msg, msgMAC []byte) error {
 		return errors.Errorf("HMAC would not validate. given: %x expected: %x", msgMAC, expectedMac)
 	}
 	return nil
-}
-
-func fromRTAMO(content string) bool {
-	return rtamo.MatchString(content)
 }

--- a/attributioncode/validator_test.go
+++ b/attributioncode/validator_test.go
@@ -152,13 +152,17 @@ func TestFromRTAMO(t *testing.T) {
 	validCodes := []string{"rta:123", "rta:abc"}
 
 	for _, v := range invalidCodes {
-		if fromRTAMO(v) {
+		c := Code{Content: v}
+
+		if c.FromRTAMO() {
 			t.Errorf("Invalid code matched regex: %s", v)
 		}
 	}
 
 	for _, v := range validCodes {
-		if !fromRTAMO(v) {
+		c := Code{Content: v}
+
+		if !c.FromRTAMO() {
 			t.Errorf("Valid code did not match regex: %s", v)
 		}
 	}

--- a/stubservice/stubhandlers/redirect.go
+++ b/stubservice/stubhandlers/redirect.go
@@ -17,6 +17,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// This prefix is prepended to the product value when we construct a storage key
+// and the attribution code contains data for RTAMO.
+const rtamoProductPrefix = "rtamo-"
+
 // redirectHandler serves redirects to modified stub binaries
 type redirectHandler struct {
 	CDNPrefix string
@@ -58,6 +62,14 @@ func (s *redirectHandler) ServeStub(w http.ResponseWriter, req *http.Request, co
 	filename, err := url.QueryUnescape(path.Base(cdnURL))
 	if err != nil {
 		return errors.Wrap(err, "QueryUnescape")
+	}
+
+	if code.FromRTAMO() {
+		product = rtamoProductPrefix + product
+		logrus.WithFields(logrus.Fields{
+			"prefix":  rtamoProductPrefix,
+			"product": product,
+		}).Info("Updated product value in storage key for RTAMO")
 	}
 
 	key := (s.KeyPrefix + "builds/" +


### PR DESCRIPTION
This is needed to fix an issue that currently blocks Extended RTAMO, see: https://github.com/mozilla-services/stubattribution/issues/108

By having this prefix, it should be possible to enforce a referer header check on the CDN itself.