### PR TITLE
Update test client base URL (and add some docs)

### DIFF
--- a/testing/stubtestclient/main.go
+++ b/testing/stubtestclient/main.go
@@ -48,7 +48,7 @@ func randomString(length int) string {
 func init() {
 	rand.Seed(time.Now().UnixNano())
 
-	flag.StringVar(&baseURL, "baseurl", "https://stubattribution-default.stage.mozaws.net", "base stub attribution service url")
+	flag.StringVar(&baseURL, "baseurl", "https://stage.stubattribution.nonprod.cloudops.mozgcp.net", "base stub attribution service url")
 
 	flag.StringVar(&campaign, "campaign", "testcampaign", "campaign")
 	flag.StringVar(&content, "content", "testcontent", "content")


### PR DESCRIPTION
This patch updates the base URL to avoid having to set it on the command
line every time, and adds some docs related (but not limited) to RTAMO
to use the stub service and the client locally, without any dependency.