### PR TITLE
Update README to note that full installer attribution is supported as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Stub Attribution [![CircleCI](https://circleci.com/gh/mozilla-services/stubattribution.svg?style=svg)](https://circleci.com/gh/mozilla-services/stubattribution) [![GoDoc](https://godoc.org/github.com/mozilla-services/stubattribution?status.svg)](https://godoc.org/github.com/mozilla-services/stubattribution)
-A service which accepts an attribution code and returns a modified stub installer.
+A service which accepts an attribution code and returns a modified installer. Despite its name, it can (and does) provide attribution for both stub and full installers.


### PR DESCRIPTION
Ideally we'd rename this service to `installerattribution` or some such - but that's probably more work than its worth.