### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Let's enable Dependabot to keep the project's dependencies up-to-date. More info at: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates

This config should be a good start.