### PR TITLE
attributioncode: use uuid.NewString()

### DIFF
--- a/attributioncode/validator.go
+++ b/attributioncode/validator.go
@@ -54,8 +54,7 @@ var excludedAttributionKeys = []string{
 var base64Decoder = base64.URLEncoding.WithPadding('.')
 
 func generateDownloadToken() string {
-	token := uuid.New()
-	return token.String()
+	return uuid.NewString()
 }
 
 // Code represents a valid attribution code


### PR DESCRIPTION
This function has been added in v1.2.0: https://pkg.go.dev/github.com/google/uuid#NewString