### PR TITLE
Add support for session_id field

### DIFF
--- a/attributioncode/validator.go
+++ b/attributioncode/validator.go
@@ -36,6 +36,7 @@ var validAttributionKeys = map[string]bool{
 	"variation":      true,
 	"ua":             true,
 	"visit_id":       true, // https://bugzilla.mozilla.org/show_bug.cgi?id=1677497
+	"session_id":     true, // https://bugzilla.mozilla.org/show_bug.cgi?id=1809120
 }
 
 // If any of these are not set in the incoming payload, they will be set to '(not set)'
@@ -49,6 +50,7 @@ var requiredAttributionKeys = []string{
 // These are not written to the installer.
 var excludedAttributionKeys = []string{
 	"visit_id",
+	"session_id",
 }
 
 var base64Decoder = base64.URLEncoding.WithPadding('.')
@@ -68,6 +70,7 @@ type Code struct {
 	Variation     string
 	UA            string
 	VisitID       string
+	SessionID     string
 
 	downloadToken string
 
@@ -188,6 +191,7 @@ func (v *Validator) Validate(code, sig, refererHeader string) (*Code, error) {
 		Variation:     vals.Get("variation"),
 		UA:            vals.Get("ua"),
 		VisitID:       vals.Get("visit_id"),
+		SessionID:     vals.Get("session_id"),
 
 		rawURLVals: vals,
 	}

--- a/attributioncode/validator_test.go
+++ b/attributioncode/validator_test.go
@@ -80,6 +80,16 @@ func TestValidateAttributionCode(t *testing.T) {
 			"campaign%3Damo-fx-cta-3006%26content%3Drta%253Ae2I5ZGIxNmE0LTZlZGMtNDdlYy1hMWY0LWI4NjI5MmVkMjExZH0%26dltoken%3D__DL_TOKEN__%26experiment%3D%2528not%2Bset%2529%26medium%3Dreferral%26source%3Daddons.mozilla.org%26ua%3Dedge%26variation%3D%2528not%2Bset%2529",
 			"https://www.mozilla.org/test/other/paths",
 		},
+		{
+			"Y2FtcGFpZ249dGVzdGNhbXBhaWduJmNvbnRlbnQ9dGVzdGNvbnRlbnQmZXhwZXJpbWVudD1leHAxJmluc3RhbGxlcl90eXBlPWZ1bGwmbWVkaXVtPXRlc3RtZWRpdW0mc2Vzc2lvbl9pZD0mc291cmNlPW1vemlsbGEuY29tJnRpbWVzdGFtcD0xNjcwMzU4ODc2JnZhcmlhdGlvbj12YXIxJnZpc2l0X2lkPXZpZA..", // campaign=testcampaign&content=testcontent&experiment=exp1&installer_type=full&medium=testmedium&source=mozilla.com&timestamp=1670358814&variation=var1&visit_id=vid&session_id=(not set)
+			"campaign%3Dtestcampaign%26content%3Dtestcontent%26dltoken%3D__DL_TOKEN__%26experiment%3Dexp1%26installer_type%3Dfull%26medium%3Dtestmedium%26source%3Dmozilla.com%26variation%3Dvar1",
+			"",
+		},
+		{
+			"Y2FtcGFpZ249dGVzdGNhbXBhaWduJmNvbnRlbnQ9dGVzdGNvbnRlbnQmZXhwZXJpbWVudD1leHAxJmluc3RhbGxlcl90eXBlPWZ1bGwmbWVkaXVtPXRlc3RtZWRpdW0mc2Vzc2lvbl9pZD1zaWQmc291cmNlPW1vemlsbGEuY29tJnRpbWVzdGFtcD0xNjcwMzU4NTc1JnZhcmlhdGlvbj12YXIxJnZpc2l0X2lkPXZpZA..", // campaign=testcampaign&content=testcontent&experiment=exp1&installer_type=full&medium=testmedium&source=mozilla.com&timestamp=1670358814&variation=var1&visit_id=vid&session_id=sid
+			"campaign%3Dtestcampaign%26content%3Dtestcontent%26dltoken%3D__DL_TOKEN__%26experiment%3Dexp1%26installer_type%3Dfull%26medium%3Dtestmedium%26source%3Dmozilla.com%26variation%3Dvar1",
+			"",
+		},
 	}
 	for _, c := range validCodes {
 		code, err := v.Validate(c.In, "", c.RefererHeader)

--- a/stubservice/stubhandlers/stubservice.go
+++ b/stubservice/stubhandlers/stubservice.go
@@ -43,9 +43,10 @@ func (s *stubService) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	logrus.WithFields(
 		logrus.Fields{
-			"log_type": "download_started",
-			"dltoken":  code.DownloadToken(),
-			"visit_id": code.VisitID,
+			"log_type":   "download_started",
+			"dltoken":    code.DownloadToken(),
+			"visit_id":   code.VisitID,
+			"session_id": code.SessionID,
 		},
 	).Info("Download Started")
 
@@ -80,9 +81,10 @@ func (s *stubService) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	logrus.WithFields(
 		logrus.Fields{
-			"log_type": "download_finished",
-			"dltoken":  code.DownloadToken(),
-			"visit_id": code.VisitID,
+			"log_type":   "download_finished",
+			"dltoken":    code.DownloadToken(),
+			"visit_id":   code.VisitID,
+			"session_id": code.SessionID,
 		},
 	).Info("Download Finished")
 }

--- a/testing/stubtestclient/main.go
+++ b/testing/stubtestclient/main.go
@@ -23,6 +23,7 @@ var (
 	experiment    string
 	variation     string
 	visitID       string
+	sessionID     string
 
 	lang    string
 	os      string
@@ -58,6 +59,7 @@ func init() {
 	flag.StringVar(&variation, "variation", "var1", "variation")
 	flag.StringVar(&installerType, "installer_type", "full", "installer_type")
 	flag.StringVar(&visitID, "visit_id", "vid", "visit_id")
+	flag.StringVar(&sessionID, "session_id", "sid", "session_id")
 
 	flag.StringVar(&lang, "lang", "en-US", "")
 	flag.StringVar(&os, "os", "win", "")
@@ -78,6 +80,7 @@ func genCode() string {
 	query.Set("installer_type", installerType)
 	query.Set("variation", variation)
 	query.Set("visit_id", visitID)
+	query.Set("session_id", sessionID)
 	query.Set("timestamp", fmt.Sprintf("%d", time.Now().UTC().Unix()))
 
 	b64Query := base64.URLEncoding.WithPadding('.').EncodeToString([]byte(query.Encode()))


### PR DESCRIPTION
Fixes https://github.com/mozilla-services/stubattribution/issues/112

---

This PR adds support for a new `session_id` field that is logged along
with the `visit_id` and `dltoken`.