### PR TITLE
Configure Sentry release based on the version.json file when possible

### DIFF
--- a/stubservice/README.md
+++ b/stubservice/README.md
@@ -57,3 +57,7 @@ A path prefix within the `GCS_BUCKET` where builds will be written.
 ### CDN_PREFIX (redirect mode)
 
 A prefix which will be added to the storage key.
+
+### DEBUG_MODE
+
+If set to a truthy value, enable debug mode, which should be more verbose.


### PR DESCRIPTION
Fixes #145

---

This patch configures Sentry with the "right" release value based on the
`version.json` file (Dockerflow).

In addition, a new `DEBUG_MODE` env variable has been introduced to
enable debug logs (and set the Sentry debug flag). This wasn't strictly
needed but I wanted to use `logrus.Debug()`, which is not printed by
default.