### PR TITLE
Accept `client_id` as an alias of `visit_id`

### DIFF
--- a/attributioncode/validator_test.go
+++ b/attributioncode/validator_test.go
@@ -51,44 +51,87 @@ func TestValidateAttributionCode(t *testing.T) {
 	v := &Validator{}
 
 	validCodes := []struct {
-		In            string
-		Out           string
-		RefererHeader string
+		In                string
+		Out               string
+		RefererHeader     string
+		ExpectedClientID  string
+		ExpectedSessionID string
 	}{
 		{
 			"c291cmNlPXd3dy5nb29nbGUuY29tJm1lZGl1bT1vcmdhbmljJmNhbXBhaWduPShub3Qgc2V0KSZjb250ZW50PShub3Qgc2V0KQ..", // source=www.google.com&medium=organic&campaign=(not set)&content=(not set)
 			"campaign%3D%2528not%2Bset%2529%26content%3D%2528not%2Bset%2529%26dltoken%3D__DL_TOKEN__%26medium%3Dorganic%26source%3Dwww.google.com",
+			"",
+			"",
 			"",
 		},
 		{
 			"c291cmNlPXd3dy5nb29nbGUuY29tJm1lZGl1bT1vcmdhbmljJmNhbXBhaWduPShub3Qgc2V0KQ..", // source=www.google.com&medium=organic&campaign=(not set)
 			"campaign%3D%2528not%2Bset%2529%26content%3D%2528not%2Bset%2529%26dltoken%3D__DL_TOKEN__%26medium%3Dorganic%26source%3Dwww.google.com",
 			"",
+			"",
+			"",
 		},
 		{
 			"c291cmNlPXd3dy5nb29nbGUuY29tJm1lZGl1bT1vcmdhbmljJmNhbXBhaWduPShub3Qgc2V0KSZjb250ZW50PShub3Qgc2V0KSZ2YXJpYXRpb249ZjEmZXhwZXJpbWVudD1lMQ..", // source=www.google.com&medium=organic&campaign=(not set)&content=(not set)&variation=f1&experiment=e1
 			"campaign%3D%2528not%2Bset%2529%26content%3D%2528not%2Bset%2529%26dltoken%3D__DL_TOKEN__%26experiment%3De1%26medium%3Dorganic%26source%3Dwww.google.com%26variation%3Df1",
+			"",
+			"",
 			"",
 		},
 		{
 			"c291cmNlPWFkZG9ucy5tb3ppbGxhLm9yZyZtZWRpdW09cmVmZXJyYWwmY2FtcGFpZ249YW1vLWZ4LWN0YS0zMDA2JmNvbnRlbnQ9cnRhOmUySTVaR0l4Tm1FMExUWmxaR010TkRkbFl5MWhNV1kwTFdJNE5qSTVNbVZrTWpFeFpIMCZleHBlcmltZW50PShub3Qgc2V0KSZ2YXJpYXRpb249KG5vdCBzZXQpJnVhPWVkZ2UmdmlzaXRfaWQ9KG5vdCBzZXQp", // source=addons.mozilla.org&medium=referral&campaign=amo-fx-cta-3006&content=rta:e2I5ZGIxNmE0LTZlZGMtNDdlYy1hMWY0LWI4NjI5MmVkMjExZH0&experiment=(not set)&variation=(not set)&ua=edge&visit_id=(not set)
 			"campaign%3Damo-fx-cta-3006%26content%3Drta%253Ae2I5ZGIxNmE0LTZlZGMtNDdlYy1hMWY0LWI4NjI5MmVkMjExZH0%26dltoken%3D__DL_TOKEN__%26experiment%3D%2528not%2Bset%2529%26medium%3Dreferral%26source%3Daddons.mozilla.org%26ua%3Dedge%26variation%3D%2528not%2Bset%2529",
 			"https://www.mozilla.org/",
+			"(not set)",
+			"",
 		},
 		{
 			"c291cmNlPWFkZG9ucy5tb3ppbGxhLm9yZyZtZWRpdW09cmVmZXJyYWwmY2FtcGFpZ249YW1vLWZ4LWN0YS0zMDA2JmNvbnRlbnQ9cnRhOmUySTVaR0l4Tm1FMExUWmxaR010TkRkbFl5MWhNV1kwTFdJNE5qSTVNbVZrTWpFeFpIMCZleHBlcmltZW50PShub3Qgc2V0KSZ2YXJpYXRpb249KG5vdCBzZXQpJnVhPWVkZ2UmdmlzaXRfaWQ9KG5vdCBzZXQp", // source=addons.mozilla.org&medium=referral&campaign=amo-fx-cta-3006&content=rta:e2I5ZGIxNmE0LTZlZGMtNDdlYy1hMWY0LWI4NjI5MmVkMjExZH0&experiment=(not set)&variation=(not set)&ua=edge&visit_id=(not set)
 			"campaign%3Damo-fx-cta-3006%26content%3Drta%253Ae2I5ZGIxNmE0LTZlZGMtNDdlYy1hMWY0LWI4NjI5MmVkMjExZH0%26dltoken%3D__DL_TOKEN__%26experiment%3D%2528not%2Bset%2529%26medium%3Dreferral%26source%3Daddons.mozilla.org%26ua%3Dedge%26variation%3D%2528not%2Bset%2529",
 			"https://www.mozilla.org/test/other/paths",
+			"(not set)",
+			"",
 		},
 		{
-			"Y2FtcGFpZ249dGVzdGNhbXBhaWduJmNvbnRlbnQ9dGVzdGNvbnRlbnQmZXhwZXJpbWVudD1leHAxJmluc3RhbGxlcl90eXBlPWZ1bGwmbWVkaXVtPXRlc3RtZWRpdW0mc2Vzc2lvbl9pZD0mc291cmNlPW1vemlsbGEuY29tJnRpbWVzdGFtcD0xNjcwMzU4ODc2JnZhcmlhdGlvbj12YXIxJnZpc2l0X2lkPXZpZA..", // campaign=testcampaign&content=testcontent&experiment=exp1&installer_type=full&medium=testmedium&source=mozilla.com&timestamp=1670358814&variation=var1&visit_id=vid&session_id=(not set)
+			"Y2FtcGFpZ249dGVzdGNhbXBhaWduJmNvbnRlbnQ9dGVzdGNvbnRlbnQmZXhwZXJpbWVudD1leHAxJmluc3RhbGxlcl90eXBlPWZ1bGwmbWVkaXVtPXRlc3RtZWRpdW0mc2Vzc2lvbl9pZD0mc291cmNlPW1vemlsbGEuY29tJnRpbWVzdGFtcD0xNjcwMzU4ODc2JnZhcmlhdGlvbj12YXIxJnZpc2l0X2lkPXZpZA..", // campaign=testcampaign&content=testcontent&experiment=exp1&installer_type=full&medium=testmedium&source=mozilla.com&timestamp=1670358814&variation=var1&visit_id=vid
 			"campaign%3Dtestcampaign%26content%3Dtestcontent%26dltoken%3D__DL_TOKEN__%26experiment%3Dexp1%26installer_type%3Dfull%26medium%3Dtestmedium%26source%3Dmozilla.com%26variation%3Dvar1",
+			"",
+			"vid",
 			"",
 		},
 		{
 			"Y2FtcGFpZ249dGVzdGNhbXBhaWduJmNvbnRlbnQ9dGVzdGNvbnRlbnQmZXhwZXJpbWVudD1leHAxJmluc3RhbGxlcl90eXBlPWZ1bGwmbWVkaXVtPXRlc3RtZWRpdW0mc2Vzc2lvbl9pZD1zaWQmc291cmNlPW1vemlsbGEuY29tJnRpbWVzdGFtcD0xNjcwMzU4NTc1JnZhcmlhdGlvbj12YXIxJnZpc2l0X2lkPXZpZA..", // campaign=testcampaign&content=testcontent&experiment=exp1&installer_type=full&medium=testmedium&source=mozilla.com&timestamp=1670358814&variation=var1&visit_id=vid&session_id=sid
 			"campaign%3Dtestcampaign%26content%3Dtestcontent%26dltoken%3D__DL_TOKEN__%26experiment%3Dexp1%26installer_type%3Dfull%26medium%3Dtestmedium%26source%3Dmozilla.com%26variation%3Dvar1",
 			"",
+			// `visit_id` is present, `client_id` isn't.
+			"vid",
+			"sid",
+		},
+		{
+			"Y2FtcGFpZ249dGVzdGNhbXBhaWduJmNsaWVudF9pZD1jaWQmY29udGVudD10ZXN0Y29udGVudCZleHBlcmltZW50PWV4cDEmaW5zdGFsbGVyX3R5cGU9ZnVsbCZtZWRpdW09dGVzdG1lZGl1bSZzZXNzaW9uX2lkPXNpZCZzb3VyY2U9bW96aWxsYS5jb20mdGltZXN0YW1wPTE2NzcxNjU2MjgmdmFyaWF0aW9uPXZhcjE.", // campaign=testcampaign&client_id=cid&content=testcontent&experiment=exp1&installer_type=full&medium=testmedium&session_id=sid&source=mozilla.com&timestamp=1677165697&variation=var1
+			"campaign%3Dtestcampaign%26content%3Dtestcontent%26dltoken%3D__DL_TOKEN__%26experiment%3Dexp1%26installer_type%3Dfull%26medium%3Dtestmedium%26source%3Dmozilla.com%26variation%3Dvar1",
+			"",
+			// `client_id` is present, `visit_id` isn't.
+			"cid",
+			"sid",
+		},
+		{
+			"Y2FtcGFpZ249dGVzdGNhbXBhaWduJmNsaWVudF9pZD1jaWQmY29udGVudD10ZXN0Y29udGVudCZleHBlcmltZW50PWV4cDEmaW5zdGFsbGVyX3R5cGU9ZnVsbCZtZWRpdW09dGVzdG1lZGl1bSZzZXNzaW9uX2lkPXNpZCZzb3VyY2U9bW96aWxsYS5jb20mdGltZXN0YW1wPTE2NzcxNjY1NjEmdmFyaWF0aW9uPXZhcjEmdmlzaXRfaWQ9dmlk", // campaign=testcampaign&client_id=cid&content=testcontent&experiment=exp1&installer_type=full&medium=testmedium&session_id=sid&source=mozilla.com&timestamp=1677166561&variation=var1&visit_id=vid
+			"campaign%3Dtestcampaign%26content%3Dtestcontent%26dltoken%3D__DL_TOKEN__%26experiment%3Dexp1%26installer_type%3Dfull%26medium%3Dtestmedium%26source%3Dmozilla.com%26variation%3Dvar1",
+			"",
+			// Both `client_id` and `visit_id` are passed. In this case, `client_id`,
+			// which is non-empty, is preferred.
+			"cid",
+			"sid",
+		},
+		{
+			"Y2FtcGFpZ249dGVzdGNhbXBhaWduJmNsaWVudF9pZD0mY29udGVudD10ZXN0Y29udGVudCZleHBlcmltZW50PWV4cDEmaW5zdGFsbGVyX3R5cGU9ZnVsbCZtZWRpdW09dGVzdG1lZGl1bSZzZXNzaW9uX2lkPXNpZCZzb3VyY2U9bW96aWxsYS5jb20mdGltZXN0YW1wPTE2NzcxNjY3MTgmdmFyaWF0aW9uPXZhcjEmdmlzaXRfaWQ9dmlk", // campaign=testcampaign&client_id=&content=testcontent&experiment=exp1&installer_type=full&medium=testmedium&session_id=sid&source=mozilla.com&timestamp=1677166718&variation=var1&visit_id=vid
+			"campaign%3Dtestcampaign%26content%3Dtestcontent%26dltoken%3D__DL_TOKEN__%26experiment%3Dexp1%26installer_type%3Dfull%26medium%3Dtestmedium%26source%3Dmozilla.com%26variation%3Dvar1",
+			"",
+			// Both `client_id` and `visit_id` are passed but `client_id` is an empty
+			// string so we prefer `visit_id`.
+			"vid",
+			"sid",
 		},
 	}
 	for _, c := range validCodes {
@@ -96,9 +139,18 @@ func TestValidateAttributionCode(t *testing.T) {
 		if err != nil {
 			t.Errorf("err: %v, code: %s", err, c.In)
 		}
+
 		res := code.URLEncode()
 		if res != strings.ReplaceAll(c.Out, "__DL_TOKEN__", code.DownloadToken()) {
 			t.Errorf("res:%s != out:%s, code: %s", res, c.Out, c.In)
+		}
+
+		if c.ExpectedClientID != code.ClientID {
+			t.Errorf("Expected ClientID: '%s', got: '%s', code: %s", c.ExpectedClientID, code.ClientID, c.In)
+		}
+
+		if c.ExpectedSessionID != code.SessionID {
+			t.Errorf("Expected SessionID: '%s', got: '%s', code: %s", c.ExpectedSessionID, code.SessionID, c.In)
 		}
 	}
 

--- a/stubservice/stubhandlers/redirect.go
+++ b/stubservice/stubhandlers/redirect.go
@@ -103,11 +103,11 @@ func (s *redirectHandler) ServeStub(w http.ResponseWriter, req *http.Request, co
 	}
 
 	stubLocation := s.CDNPrefix + key
-	stubLocationUrl, err := url.Parse(stubLocation)
+	stubLocationURL, err := url.Parse(stubLocation)
 	if err != nil {
 		return errors.Wrap(err, "url.Parse")
 	}
-	http.Redirect(w, req, stubLocationUrl.String(), http.StatusFound)
+	http.Redirect(w, req, stubLocationURL.String(), http.StatusFound)
 	logrus.WithFields(logrus.Fields{
 		"req_url":  req.URL.String(),
 		"location": stubLocation}).Info("Redirected request")

--- a/stubservice/stubhandlers/stubservice.go
+++ b/stubservice/stubhandlers/stubservice.go
@@ -43,9 +43,15 @@ func (s *stubService) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	logrus.WithFields(
 		logrus.Fields{
-			"log_type":   "download_started",
-			"dltoken":    code.DownloadToken(),
-			"visit_id":   code.VisitID,
+			"log_type": "download_started",
+			"dltoken":  code.DownloadToken(),
+			// This field should be named `client_id` but, for historical reasons, we
+			// use `visit_id`. It'd be good to be able to rename this field but we
+			// need to work with the Data Science team since that'd be a breaking
+			// change.
+			//
+			// See: https://github.com/mozilla-services/stubattribution/issues/153
+			"visit_id":   code.ClientID,
 			"session_id": code.SessionID,
 		},
 	).Info("Download Started")
@@ -81,9 +87,15 @@ func (s *stubService) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	logrus.WithFields(
 		logrus.Fields{
-			"log_type":   "download_finished",
-			"dltoken":    code.DownloadToken(),
-			"visit_id":   code.VisitID,
+			"log_type": "download_finished",
+			"dltoken":  code.DownloadToken(),
+			// This field should be named `client_id` but, for historical reasons, we
+			// use `visit_id`. It'd be good to be able to rename this field but we
+			// need to work with the Data Science team since that'd be a breaking
+			// change.
+			//
+			// See: https://github.com/mozilla-services/stubattribution/issues/153
+			"visit_id":   code.ClientID,
 			"session_id": code.SessionID,
 		},
 	).Info("Download Finished")

--- a/testing/stubtestclient/main.go
+++ b/testing/stubtestclient/main.go
@@ -22,7 +22,7 @@ var (
 	source        string
 	experiment    string
 	variation     string
-	visitID       string
+	clientID      string
 	sessionID     string
 
 	lang    string
@@ -58,7 +58,7 @@ func init() {
 	flag.StringVar(&experiment, "experiment", "exp1", "experiment")
 	flag.StringVar(&variation, "variation", "var1", "variation")
 	flag.StringVar(&installerType, "installer_type", "full", "installer_type")
-	flag.StringVar(&visitID, "visit_id", "vid", "visit_id")
+	flag.StringVar(&clientID, "client_id", "cid", "client_id")
 	flag.StringVar(&sessionID, "session_id", "sid", "session_id")
 
 	flag.StringVar(&lang, "lang", "en-US", "")
@@ -79,7 +79,7 @@ func genCode() string {
 	query.Set("experiment", experiment)
 	query.Set("installer_type", installerType)
 	query.Set("variation", variation)
-	query.Set("visit_id", visitID)
+	query.Set("client_id", clientID)
 	query.Set("session_id", sessionID)
 	query.Set("timestamp", fmt.Sprintf("%d", time.Now().UTC().Unix()))
 


### PR DESCRIPTION
Fixes https://github.com/mozilla-services/stubattribution/issues/153

---

The visit ID field is in fact the Google Analytics 'client' ID.

Note that we simply rename the field internally, we do not change the log statements to avoid breaking things (used by the DS team).