### PR TITLE
Support dlsource as an attribution parameter (fixes #159)

### DIFF
--- a/attributioncode/validator.go
+++ b/attributioncode/validator.go
@@ -74,7 +74,7 @@ type Code struct {
 	UA            string
 	ClientID      string
 	SessionID     string
-	DlSource      string
+	DownloadSource      string
 
 	downloadToken string
 

--- a/attributioncode/validator.go
+++ b/attributioncode/validator.go
@@ -38,6 +38,7 @@ var validAttributionKeys = map[string]bool{
 	"visit_id":       true, // https://bugzilla.mozilla.org/show_bug.cgi?id=1677497
 	"session_id":     true, // https://bugzilla.mozilla.org/show_bug.cgi?id=1809120
 	"client_id":      true, // Alias of `visit_id`.
+	"dlsource":       true, // https://github.com/mozilla-services/stubattribution/issues/159
 }
 
 // If any of these are not set in the incoming payload, they will be set to '(not set)'
@@ -73,6 +74,7 @@ type Code struct {
 	UA            string
 	ClientID      string
 	SessionID     string
+	DlSource      string
 
 	downloadToken string
 
@@ -204,6 +206,7 @@ func (v *Validator) Validate(code, sig, refererHeader string) (*Code, error) {
 		UA:            vals.Get("ua"),
 		ClientID:      clientID,
 		SessionID:     vals.Get("session_id"),
+		DlSource:      vals.Get("dlsource"),
 
 		rawURLVals: vals,
 	}

--- a/attributioncode/validator.go
+++ b/attributioncode/validator.go
@@ -64,17 +64,17 @@ func generateDownloadToken() string {
 
 // Code represents a valid attribution code
 type Code struct {
-	Source        string
-	Medium        string
-	Campaign      string
-	Content       string
-	Experiment    string
-	InstallerType string
-	Variation     string
-	UA            string
-	ClientID      string
-	SessionID     string
-	DownloadSource      string
+	Source         string
+	Medium         string
+	Campaign       string
+	Content        string
+	Experiment     string
+	InstallerType  string
+	Variation      string
+	UA             string
+	ClientID       string
+	SessionID      string
+	DownloadSource string
 
 	downloadToken string
 
@@ -196,17 +196,17 @@ func (v *Validator) Validate(code, sig, refererHeader string) (*Code, error) {
 	}
 
 	attributionCode := &Code{
-		Source:        vals.Get("source"),
-		Medium:        vals.Get("medium"),
-		Campaign:      vals.Get("campaign"),
-		Content:       vals.Get("content"),
-		Experiment:    vals.Get("experiment"),
-		InstallerType: vals.Get("installer_type"),
-		Variation:     vals.Get("variation"),
-		UA:            vals.Get("ua"),
-		ClientID:      clientID,
-		SessionID:     vals.Get("session_id"),
-		DlSource:      vals.Get("dlsource"),
+		Source:         vals.Get("source"),
+		Medium:         vals.Get("medium"),
+		Campaign:       vals.Get("campaign"),
+		Content:        vals.Get("content"),
+		Experiment:     vals.Get("experiment"),
+		InstallerType:  vals.Get("installer_type"),
+		Variation:      vals.Get("variation"),
+		UA:             vals.Get("ua"),
+		ClientID:       clientID,
+		SessionID:      vals.Get("session_id"),
+		DownloadSource: vals.Get("dlsource"),
 
 		rawURLVals: vals,
 	}

--- a/attributioncode/validator.go
+++ b/attributioncode/validator.go
@@ -38,7 +38,7 @@ var validAttributionKeys = map[string]bool{
 	"visit_id":       true, // https://bugzilla.mozilla.org/show_bug.cgi?id=1677497
 	"session_id":     true, // https://bugzilla.mozilla.org/show_bug.cgi?id=1809120
 	"client_id":      true, // Alias of `visit_id`.
-	"dlsource":       true, // https://github.com/mozilla-services/stubattribution/issues/159
+	"dlsource":       true,
 }
 
 // If any of these are not set in the incoming payload, they will be set to '(not set)'

--- a/attributioncode/validator_test.go
+++ b/attributioncode/validator_test.go
@@ -133,6 +133,13 @@ func TestValidateAttributionCode(t *testing.T) {
 			"vid",
 			"sid",
 		},
+		{
+			"Y2FtcGFpZ249dGVzdGNhbXBhaWduJmNvbnRlbnQ9dGVzdGNvbnRlbnQmZXhwZXJpbWVudD1leHAxJmluc3RhbGxlcl90eXBlPWZ1bGwmbWVkaXVtPXRlc3RtZWRpdW0mc291cmNlPW1vemlsbGEuY29tJnRpbWVzdGFtcD0xNjcwMzU4ODE0JnZhcmlhdGlvbj12YXIxJmRsc291cmNlPW1vem9yZw..", // campaign=testcampaign&content=testcontent&experiment=exp1&installer_type=full&medium=testmedium&source=mozilla.com&timestamp=1670358814&variation=var1&dlsource=mozorg
+			"campaign%3Dtestcampaign%26content%3Dtestcontent%26dlsource%3Dmozorg%26dltoken%3D__DL_TOKEN__%26experiment%3Dexp1%26installer_type%3Dfull%26medium%3Dtestmedium%26source%3Dmozilla.com%26variation%3Dvar1",
+			"",
+			"",
+			"",
+		},
 	}
 	for _, c := range validCodes {
 		code, err := v.Validate(c.In, "", c.RefererHeader)

--- a/testing/stubtestclient/main.go
+++ b/testing/stubtestclient/main.go
@@ -24,6 +24,7 @@ var (
 	variation     string
 	clientID      string
 	sessionID     string
+	dlsource      string
 
 	lang    string
 	os      string
@@ -60,6 +61,7 @@ func init() {
 	flag.StringVar(&installerType, "installer_type", "full", "installer_type")
 	flag.StringVar(&clientID, "client_id", "cid", "client_id")
 	flag.StringVar(&sessionID, "session_id", "sid", "session_id")
+	flag.StringVar(&dlsource, "dlsource", "testmozorg", "dlsource")
 
 	flag.StringVar(&lang, "lang", "en-US", "")
 	flag.StringVar(&os, "os", "win", "")


### PR DESCRIPTION
@willdurand - I think this covers most, if not everything? I tried to use the stubtestclient locally, but wasn't able to make it work (I presume I need some GCS or AWS creds set-up...)