### PR TITLE
Default to Windows attribution when the `os` value is not "osx"

### DIFF
--- a/stubservice/stubhandlers/stubservice.go
+++ b/stubservice/stubhandlers/stubservice.go
@@ -21,7 +21,7 @@ func NewStubService(stubHandler StubHandler, validator *attributioncode.Validato
 	return &stubService{
 		Handler:                  stubHandler,
 		AttributionCodeValidator: validator,
-		BouncerBaseURL: bouncerBaseURL,
+		BouncerBaseURL:           bouncerBaseURL,
 	}
 }
 


### PR DESCRIPTION
Fixes #203

---

Technically, this reverts to the "old" behavior (which is currently deployed on prod).

I feel like this approach is (slightly) safer than maintaining a list of "os" values in this project too but I might be wrong.

In addition to avoid the panic, this PR allows to attribute full Windows x64 buids again.