### PR TITLE
Downgrade log level for the 'unexpected URL path' error so that it doesn't get sent to Sentry anymore

### DIFF
--- a/stubservice/main.go
+++ b/stubservice/main.go
@@ -218,7 +218,7 @@ func main() {
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		// Only respond to requests for which the path *exactly* matches "/".
 		if r.URL.Path != "/" {
-			logrus.WithField("path", r.URL.Path).Error("Got unexpected URL path")
+			logrus.WithField("path", r.URL.Path).Warn("Got unexpected URL path")
 			http.NotFound(w, r)
 			return
 		}


### PR DESCRIPTION
I reviewed some of the most recent entries again and I am not sure
there is _any_ valid call with an URL path that isn't `/` so I'd
propose to no longer send the error to Sentry.

The log statement should still be visible in the (GCP) logs.